### PR TITLE
Return success and failure messages

### DIFF
--- a/.github/workflows/Sweave2rmd.yaml
+++ b/.github/workflows/Sweave2rmd.yaml
@@ -39,16 +39,16 @@ jobs:
                    msgs <- ""
                    for (fname in list.files(path = ".", pattern = "\\.rnw$", ignore.case = TRUE)) {
                      msg <- tryCatch({
-                       print(paste("Converting", fname))
                        Rnw2Rmd::Rnw2Rmd(from = fname,
                                         to = sub("rnw", "Rmd", x = fname, ignore.case = TRUE),
                                         validate = FALSE)
+                       paste(fname, "converted.")
                      }, error = function(e) {
-                       return(paste(fname, "must be converted manually.", sep=" "))
+                       paste(fname, "must be converted manually.")
                      })
                      msgs <- paste(msgs, msg) 
                    }
-                   print(paste("Final Message:", msgs))
+                   print(msgs)
                   '
       - name: git add
         run: |

--- a/.github/workflows/Sweave2rmd.yaml
+++ b/.github/workflows/Sweave2rmd.yaml
@@ -36,19 +36,19 @@ jobs:
       - name: convert Rnw
         run: |
              R -e 'setwd("vignettes")
-                   msg <- ""
+                   msgs <- ""
                    for (fname in list.files(path = ".", pattern = "\\.rnw$", ignore.case = TRUE)) {
-                     tryCatch({
+                     msg <- tryCatch({
                        print(paste("Converting", fname))
                        Rnw2Rmd::Rnw2Rmd(from = fname,
                                         to = sub("rnw", "Rmd", x = fname, ignore.case = TRUE),
                                         validate = FALSE)
                      }, error = function(e) {
-                       msg <- paste(msg, fname, "must be converted manually.", sep=" ")
-                       print(paste("Error:", msg))
+                       return(paste(fname, "must be converted manually.", sep=" "))
                      })
+                     msgs <- paste(msgs, msg) 
                    }
-                   print(paste("Final Message:", msg))
+                   print(paste("Final Message:", msgs))
                   '
       - name: git add
         run: |

--- a/.github/workflows/Sweave2rmd.yaml
+++ b/.github/workflows/Sweave2rmd.yaml
@@ -44,7 +44,8 @@ jobs:
                                         to = sub("rnw", "Rmd", x = fname, ignore.case = TRUE),
                                         validate = FALSE)
                      }, error = function(e) {
-                       msg <- paste(msg, fname, "must be converted manually.", "Error:", e)
+                       #msg <- paste(msg, fname, "must be converted manually.", "Error:", e)
+                       print(paste("Error:", fname))
                      })
                    }
                    print(msg)

--- a/.github/workflows/Sweave2rmd.yaml
+++ b/.github/workflows/Sweave2rmd.yaml
@@ -36,20 +36,20 @@ jobs:
       - name: convert Rnw
         run: |
              R -e 'setwd("vignettes")
-                 msg <- " "
-                 for (fname in list.files(path = ".", pattern = "\\.rnw$", ignore.case = TRUE)){
+                   msg <- " "
+                   for (fname in list.files(path = ".", pattern = "\\.rnw$", ignore.case = TRUE)) {
                      tryCatch({
-                              Rnw2Rmd::Rnw2Rmd(from = fname,
-                                to = sub("rnw", "Rmd", x = fname, ignore.case = TRUE),
-                                validate = FALSE)
-                          }, error = function(e) {
-                                          msg <- paste(msg, fname, "must be converted manually.")
-                                          print("Inside the loop")
-                             }
-                             )
-                     print(msg)
-                     print("Outside the loop")
-                    }'
+                       Rnw2Rmd::Rnw2Rmd(from = fname,
+                                        to = sub("rnw", "Rmd", x = fname, ignore.case = TRUE),
+                                        validate = FALSE)
+                     }, error = function(e) {
+                       msg <- paste(msg, fname, "must be converted manually.", "Error:", e)
+                       print("Inside the loop")
+                     })
+                   }
+                   print(msg)
+                   print("Outside the loop")
+                   '
       - name: git add
         run: |
           git config --global --add safe.directory /__w/$REPO_NAME/$REPO_NAME

--- a/.github/workflows/Sweave2rmd.yaml
+++ b/.github/workflows/Sweave2rmd.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: convert Rnw
         run: |
              R -e 'setwd("vignettes")
-                   msg <- " "
+                   msg <- ""
                    for (fname in list.files(path = ".", pattern = "\\.rnw$", ignore.case = TRUE)) {
                      tryCatch({
                        print(paste("Converting", fname))
@@ -44,13 +44,12 @@ jobs:
                                         to = sub("rnw", "Rmd", x = fname, ignore.case = TRUE),
                                         validate = FALSE)
                      }, error = function(e) {
-                       #msg <- paste(msg, fname, "must be converted manually.", "Error:", e)
-                       print(paste("Error:", fname))
+                       msg <- paste(msg, fname, "must be converted manually.", sep=" ")
+                       print(paste("Error:", msg))
                      })
                    }
-                   print(msg)
-                   print("Outside the loop")
-                   '
+                   print(paste("Final Message:", msg))
+                  '
       - name: git add
         run: |
           git config --global --add safe.directory /__w/$REPO_NAME/$REPO_NAME

--- a/.github/workflows/Sweave2rmd.yaml
+++ b/.github/workflows/Sweave2rmd.yaml
@@ -39,12 +39,12 @@ jobs:
                    msg <- " "
                    for (fname in list.files(path = ".", pattern = "\\.rnw$", ignore.case = TRUE)) {
                      tryCatch({
+                       print(paste("Converting", fname))
                        Rnw2Rmd::Rnw2Rmd(from = fname,
                                         to = sub("rnw", "Rmd", x = fname, ignore.case = TRUE),
                                         validate = FALSE)
                      }, error = function(e) {
                        msg <- paste(msg, fname, "must be converted manually.", "Error:", e)
-                       print("Inside the loop")
                      })
                    }
                    print(msg)


### PR DESCRIPTION
The issue was that the scope is different for the global `msg` and the `msg` inside the `tryCatch` so the behavior we saw was that the global `msg` was being printed. What we can do is return a value from the `tryCatch` then add that to a global `msgs` variable. (Note: you may know this already but in R, the value of the last statement is what is returned. In the `tryCatch`, these are lines 45 and 47.